### PR TITLE
Switch back to upstream DerekStride/tree-sitter-sql

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -7,5 +7,5 @@ description = "SQL language support."
 repository = "https://github.com/zed-extensions/sql"
 
 [grammars.sql]
-repository = "https://github.com/nervenes/tree-sitter-sql"
-commit = "6dfca8b6dcb196d943c10e9cabab25e60232d332"
+repository = "https://github.com/DerekStride/tree-sitter-sql"
+commit = "4a99c73f5384f2be10adc55208c84d95a7eb1137"

--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -1,3 +1,6 @@
+(object_reference
+  name: (identifier) @type)
+
 (invocation
   (object_reference
     name: (identifier) @function.call))
@@ -11,9 +14,6 @@
   (keyword_brin)
   (keyword_array)
 ] @function.call
-
-(object_reference
-  name: (identifier) @type)
 
 (relation
   alias: (identifier) @variable)
@@ -30,9 +30,7 @@
     parameter: [(literal)]?)))
 
 (literal) @string
-[
-    (comment)
-] @comment
+(comment) @comment @spell
 (marginalia) @comment
 
 ((literal) @number
@@ -112,6 +110,8 @@
   (keyword_primary)
   (keyword_delete)
   (keyword_create)
+  (keyword_show)
+  (keyword_unload)
   (keyword_insert)
   (keyword_merge)
   (keyword_distinct)
@@ -149,9 +149,6 @@
   (keyword_for)
   (keyword_if)
   (keyword_exists)
-  (keyword_max)
-  (keyword_min)
-  (keyword_avg)
   (keyword_column)
   (keyword_columns)
   (keyword_cross)
@@ -197,7 +194,6 @@
   (keyword_current)
   (keyword_ties)
   (keyword_others)
-  (keyword_preserve)
   (keyword_zerofill)
   (keyword_format)
   (keyword_fields)
@@ -221,7 +217,6 @@
   (keyword_vacuum)
   (keyword_cache)
   (keyword_language)
-  (keyword_sql)
   (keyword_called)
   (keyword_conflict)
   (keyword_declare)
@@ -231,8 +226,6 @@
   (keyword_name)
   (keyword_oid)
   (keyword_oids)
-  (keyword_options)
-  (keyword_plpgsql)
   (keyword_precision)
   (keyword_regclass)
   (keyword_regnamespace)
@@ -276,6 +269,7 @@
   (keyword_out)
   (keyword_inout)
   (keyword_variadic)
+  (keyword_ordinality)
   (keyword_session)
   (keyword_isolation)
   (keyword_level)
@@ -306,6 +300,25 @@
   (keyword_statement)
   (keyword_execute)
   (keyword_procedure)
+  (keyword_copy)
+  (keyword_delimiter)
+  (keyword_encoding)
+  (keyword_escape)
+  (keyword_force_not_null)
+  (keyword_force_null)
+  (keyword_force_quote)
+  (keyword_freeze)
+  (keyword_header)
+  (keyword_match)
+  (keyword_program)
+  (keyword_quote)
+  (keyword_stdin)
+  (keyword_extended)
+  (keyword_main)
+  (keyword_plain)
+  (keyword_storage)
+  (keyword_compression)
+  (keyword_duplicate)
 ] @keyword
 
 [


### PR DESCRIPTION
Upstream repository now supports WASM compilation, so no need to use the fork anymore.

- Closes #10 

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/74be2027-34f1-4d2d-b829-da2547637fa7) | ![after](https://github.com/user-attachments/assets/85b8503f-3466-48c8-96fa-9869a2dbe1ef) |