### PR TITLE
Remove prettier-plugin-sql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,3 @@
-# General
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
+*.wasm
+grammars/
+target/

--- a/languages/sql/config.toml
+++ b/languages/sql/config.toml
@@ -6,5 +6,3 @@ brackets = [
     { start = "(", end = ")", close = true, newline = false },
     { start = "BEGIN", end = "END", close = true, newline = true },
 ]
-prettier_parser_name = "sql"
-prettier_plugins = ["prettier-plugin-sql"]


### PR DESCRIPTION
Remove prettier-plugin-sql because it requires specifying the SQL dialect (e.g. postgresql, mysql, etc) as the prettier language (parser) for handling postgresql/mysql dialects.  Specifying `sql` (the current behavior) forces the underlying sql-formatter library to use a generic SQL dialect which will misformat/break all sorts of non-standard operators. 

- Closes: https://github.com/zed-extensions/sql/issues/16
- Closes: https://github.com/zed-extensions/sql/issues/12

See also:
- https://github.com/zed-industries/zed/issues/9537
- https://github.com/zed-industries/zed/pull/32003