### PR TITLE
Restore comment highlighting

### DIFF
--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -30,8 +30,10 @@
     parameter: [(literal)]?)))
 
 (literal) @string
-(comment) @comment @spell
-(marginalia) @comment
+[
+  (comment)
+  (marginalia)
+] @comment
 
 ((literal) @number
    (#match? @number "^[-+]?%d+$"))


### PR DESCRIPTION
This PR is a follow-up to #15 which broke comment highlighting in SQL files.

| Before | After |
| - | - | 
| ![before](https://github.com/user-attachments/assets/d7515ab7-7ca8-439b-9a83-7341ed975220) | ![after](https://github.com/user-attachments/assets/e59dfbaf-f8e0-4305-b0a4-1401aa922dae) |

