### PR TITLE
Remove spell seems to get the inline comments working again

### DIFF
--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -30,7 +30,7 @@
     parameter: [(literal)]?)))
 
 (literal) @string
-(comment) @comment @spell
+(comment) @comment
 (marginalia) @comment
 
 ((literal) @number

--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -31,6 +31,7 @@
 
 (literal) @string
 (comment) @comment
+(comment) @spell
 (marginalia) @comment
 
 ((literal) @number

--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -31,7 +31,6 @@
 
 (literal) @string
 (comment) @comment
-(comment) @spell
 (marginalia) @comment
 
 ((literal) @number


### PR DESCRIPTION
This should solve #22 . :) 

I have tested locally in Zed and looks like the inline comment is working again.