### PR TITLE
Improve SQL highlighting

### DIFF
--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -1,5 +1,8 @@
-(object_reference
-  name: (identifier) @type)
+(identifier) @variable
+
+(object_reference (identifier) @type)
+(cte (identifier) @type)
+(relation (identifier) @type)
 
 (invocation
   (object_reference
@@ -15,10 +18,13 @@
   (keyword_array)
 ] @function.call
 
-(relation
-  alias: (identifier) @variable)
-
 (field
+  name: (identifier) @field)
+
+(column_definition
+  name: (identifier) @field)
+
+(column
   name: (identifier) @field)
 
 (term
@@ -45,6 +51,8 @@
  (keyword_true)
  (keyword_false)
 ] @boolean
+
+(keyword_null) @constant.builtin
 
 [
  (keyword_asc)
@@ -74,7 +82,7 @@
  (keyword_safe)
  (keyword_cost)
  (keyword_strict)
-] @attribute
+] @keyword
 
 [
  (keyword_materialized)
@@ -92,14 +100,14 @@
  (keyword_jsonfile)
  (keyword_sequencefile)
  (keyword_volatile)
-] @storageclass
+] @keyword
 
 [
  (keyword_case)
  (keyword_when)
  (keyword_then)
  (keyword_else)
-] @conditional
+] @keyword
 
 [
   (keyword_select)
@@ -345,11 +353,10 @@
  (keyword_statistics)
  (keyword_maxvalue)
  (keyword_minvalue)
-] @type.qualifier
+] @keyword
 
 [
   (keyword_int)
-  (keyword_null)
   (keyword_boolean)
   (keyword_binary)
   (keyword_varbinary)


### PR DESCRIPTION
| SQL v1.1.4 | With this PR |
| --- | --- |
| <img width="1000" height="1040" alt="0001" src="https://github.com/user-attachments/assets/fb6220dc-b6c1-45e9-baaa-d2df933ebade" /> | <img width="1000" height="1040" alt="0000" src="https://github.com/user-attachments/assets/55a4edd9-9fea-4b23-a463-bf3077341faa" /> |

```sql
create table schema.table (
  field boolean unique default true,
  foreign key (field) references schema.table (field)
) stored as csv;

create materialized view view as
select field from table
where field is null;

-- comment
with cte as (
  select
    case
      when table.field is null
      then true
      else table.field
    end as field
  from schema.table as table
)
select field from cte
where field is true;
```

Changes to harmonize highlighting. Scopes not in default themes were replaced.
- Scope identifiers as `variable`, `field`, `type`
- Scope keywords as `keyword`
